### PR TITLE
Fix wildcard imports in TypeScript (ES2015+ syntax)

### DIFF
--- a/handler.d.ts
+++ b/handler.d.ts
@@ -1,3 +1,5 @@
 declare function handler(options?:any):Function;
 
+declare module handler {}
+
 export = handler;


### PR DESCRIPTION
This fixes importing the error handler middleware with the wildcard ES2015 syntax:

```typescript
import * as errorHandler from 'feathers-errors/handler';
```

Imports like this were previously failing with the following error message:

```
[ts] Module '"[...]/node_modules/feathers-errors/handler"' resolves to a non-module entity and cannot be imported using this construct.
```

Only imports with the legacy/deprecated syntax were previously possible:

```typescript
import errorHandler = require('feathers-errors/handler');
```

These are no longer allowed when targetting ES2015+

✌️